### PR TITLE
Make sure all fields are copied from PendingHitDetails to HitDetail

### DIFF
--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/model/HitDetail.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/model/HitDetail.java
@@ -210,14 +210,17 @@ public class HitDetail extends BaseEntity {
 	
 	public static HitDetail from(PendingHitDetails pendingHitDetails) {
 		HitDetail hitDetail = new HitDetail(pendingHitDetails.getHitEnum());
-		hitDetail.setHitType(pendingHitDetails.getHitEnum().toString());
+		hitDetail.setFlightId(pendingHitDetails.getFlightId());
+		hitDetail.setHitType(pendingHitDetails.getHitType());
+		hitDetail.setHitEnum(pendingHitDetails.getHitEnum());
 		hitDetail.setPassengerId(pendingHitDetails.getPassengerId());
 		hitDetail.setHitMakerId(pendingHitDetails.getHitMakerId());
 		hitDetail.setRuleId(pendingHitDetails.getHitMakerId()); //Set as hitmaker Id - this field is typically based on drools hit.
 		hitDetail.setDescription(pendingHitDetails.getDescription());
-		hitDetail.setCreatedDate(new Date());
+		hitDetail.setCreatedDate(pendingHitDetails.getCreatedDate());
 		hitDetail.setTitle(pendingHitDetails.getTitle());
 		hitDetail.setRuleConditions(pendingHitDetails.getRuleConditions());
+		hitDetail.setPercentage(pendingHitDetails.getPercentage());
 		return hitDetail;
 	}
 


### PR DESCRIPTION
Before, some fields were not properly copied in the `HitDetail.from(pendingHitDetails)` method, so these fields remained in their default values. This caused bugs; for instance, the match confidence for Tamr hits would always display at 100% even if it was reported by Tamr as lower.