### PR TITLE
Send derog list to Tamr

### DIFF
--- a/gtas-parent/gtas-commons/src/main/resources/default.application.properties
+++ b/gtas-parent/gtas-commons/src/main/resources/default.application.properties
@@ -184,3 +184,7 @@ tamr.activemq.broker.url=tcp://localhost:61616
 # passenger's travel history based on their cluster ID from Tamr.
 # If tamr.enabled is false, this has no effect.
 tamr.resolve_passenger_history=true
+# By default, send updated derog list (watchlists) to Tamr at most once per
+# hour if they've changed.
+tamr.derogReplace.fixedDelay.in.milliseconds=3600000
+tamr.derogReplace.initialDelay.in.milliseconds=1000

--- a/gtas-parent/gtas-commons/src/main/resources/default.application.properties
+++ b/gtas-parent/gtas-commons/src/main/resources/default.application.properties
@@ -180,7 +180,7 @@ elastic.ssl.enabled=true
 ######### Tamr Integration #########
 tamr.enabled=false
 tamr.activemq.broker.url=tcp://localhost:61616
-# If Tamr is enabled, this option will toggle prefential resolving of a
+# If Tamr is enabled, this option will toggle preferential resolving of a
 # passenger's travel history based on their cluster ID from Tamr.
 # If tamr.enabled is false, this has no effect.
 tamr.resolve_passenger_history=true

--- a/gtas-parent/gtas-job-scheduler-war/src/main/java/gov/gtas/job/scheduler/LoaderScheduler.java
+++ b/gtas-parent/gtas-job-scheduler-war/src/main/java/gov/gtas/job/scheduler/LoaderScheduler.java
@@ -18,6 +18,7 @@ import gov.gtas.json.AuditActionTarget;
 import gov.gtas.model.MessageStatus;
 import gov.gtas.parsers.tamr.jms.TamrMessageSender;
 import gov.gtas.parsers.tamr.model.TamrPassenger;
+import gov.gtas.parsers.tamr.model.TamrQuery;
 import gov.gtas.repository.MessageStatusRepository;
 import gov.gtas.services.*;
 import gov.gtas.services.matcher.MatchingService;
@@ -110,8 +111,8 @@ public class LoaderScheduler {
 
 		if (tamrEnabled) {
 			List<TamrPassenger> passToSend = processedMessages.getTamrPassengers();
-			logger.info(String.valueOf(passToSend.size()));
-			tamrMessageSender.sendMessageToTamr("InboundQueue", passToSend);
+			TamrQuery tamrQuery = new TamrQuery(passToSend);
+			tamrMessageSender.sendMessageToTamr("QUERY", tamrQuery);
 		}
 
 		if (result != null) {

--- a/gtas-parent/gtas-job-scheduler-war/src/main/java/gov/gtas/job/scheduler/TamrDerogReplaceScheduler.java
+++ b/gtas-parent/gtas-job-scheduler-war/src/main/java/gov/gtas/job/scheduler/TamrDerogReplaceScheduler.java
@@ -1,0 +1,95 @@
+/*
+ * All GTAS code is Copyright 2016, The Department of Homeland Security (DHS), U.S. Customs and Border Protection (CBP).
+ *
+ * Please see LICENSE.txt for details.
+ */
+package gov.gtas.job.scheduler;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import gov.gtas.model.watchlist.WatchlistItem;
+import gov.gtas.parsers.tamr.TamrAdapter;
+import gov.gtas.parsers.tamr.TamrAdapterImpl;
+import gov.gtas.parsers.tamr.jms.TamrMessageSender;
+import gov.gtas.parsers.tamr.model.TamrDerogListEntry;
+import gov.gtas.parsers.tamr.model.TamrDerogListUpdate;
+import gov.gtas.repository.watchlist.WatchlistItemRepository;
+import gov.gtas.repository.watchlist.WatchlistRepository;
+
+/**
+ * Scheduler class for sending the derog list (watchlist) to Tamr when changed.
+ * Uses Spring's Scheduled annotation for scheduling tasks. The class reads
+ * configuration values from an external file.
+ * 
+ * @author Cassidy Laidlaw
+ */
+@Component
+@ConditionalOnProperty(prefix = "tamr", name = "enabled")
+public class TamrDerogReplaceScheduler {
+
+    private static final Logger logger =
+            LoggerFactory.getLogger(TamrDerogReplaceScheduler.class);
+    
+    @Autowired
+    WatchlistRepository watchlistRepository;
+    
+    @Autowired
+    WatchlistItemRepository watchlistItemRepository;
+    
+    TamrAdapter tamrAdapter = new TamrAdapterImpl();
+    
+    @Autowired
+    TamrMessageSender tamrMessageSender;
+
+    private Date lastRun = null;
+
+    /**
+     * Replace the watchlist in Tamr if the GTAS ons has changed.
+     **/
+    @Scheduled(fixedDelayString = "${tamr.derogReplace.fixedDelay.in.milliseconds}",
+            initialDelayString = "${tamr.derogReplace.initialDelay.in.milliseconds}")
+    public void jobScheduling() throws InterruptedException {
+        logger.info("Checking for watchlist edits to send to Tamr...");
+        
+        // Get the latest time that a watchlist was edited.
+        Optional<Date> latestWatchlistEdit = StreamSupport.stream(
+                watchlistRepository.findAll().spliterator(), false)
+            .map((watchlist) -> watchlist.getEditTimestamp())
+            .collect(Collectors.maxBy(Comparator.naturalOrder()));
+        
+        // Return if there are no watchlists to send.
+        if (!latestWatchlistEdit.isPresent()) return;
+        
+        // If there has been an edit to a watchlist since the last time this
+        // job was run...
+        if (lastRun == null || lastRun.before(latestWatchlistEdit.get())) {
+            logger.info("Sending latest watchlist to Tamr.");
+          
+            List<WatchlistItem> watchlistItems = new ArrayList<>();
+            watchlistItemRepository.findAll().forEach(watchlistItems::add);
+            List<TamrDerogListEntry> derogListEntries =
+                    tamrAdapter.convertWatchlist(watchlistItems);
+            TamrDerogListUpdate derogReplace =
+                    new TamrDerogListUpdate(derogListEntries);
+            tamrMessageSender.sendMessageToTamr("DC.REPLACE", derogReplace);
+            
+            lastRun = new Date();
+        } else {
+            logger.info("No recent watchlist edits found.");
+        }
+    }
+
+}

--- a/gtas-parent/gtas-parsers/src/main/java/gov/gtas/parsers/tamr/TamrDerogReplaceScheduler.java
+++ b/gtas-parent/gtas-parsers/src/main/java/gov/gtas/parsers/tamr/TamrDerogReplaceScheduler.java
@@ -3,7 +3,7 @@
  *
  * Please see LICENSE.txt for details.
  */
-package gov.gtas.job.scheduler;
+package gov.gtas.parsers.tamr;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -21,8 +21,6 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import gov.gtas.model.watchlist.WatchlistItem;
-import gov.gtas.parsers.tamr.TamrAdapter;
-import gov.gtas.parsers.tamr.TamrAdapterImpl;
 import gov.gtas.parsers.tamr.jms.TamrMessageSender;
 import gov.gtas.parsers.tamr.model.TamrDerogListEntry;
 import gov.gtas.parsers.tamr.model.TamrDerogListUpdate;

--- a/gtas-parent/gtas-parsers/src/main/java/gov/gtas/parsers/tamr/jms/TamrMessageSender.java
+++ b/gtas-parent/gtas-parsers/src/main/java/gov/gtas/parsers/tamr/jms/TamrMessageSender.java
@@ -43,10 +43,10 @@ public class TamrMessageSender {
                     messageObject.getClass(), messageType, e);
             return;
         }
-        this.sendMessageToTamr(messageType, messageJson);
+        this.sendTextMessageToTamr(messageType, messageJson);
     }
     
-    public void sendMessageToTamr(String messageType, String messageText) {
+    public void sendTextMessageToTamr(String messageType, String messageText) {
         if (jmsTemplate == null) {
             this.jmsTemplate = new JmsTemplate(
                     queueConfig.senderConnectionFactory());

--- a/gtas-parent/gtas-parsers/src/test/java/gov/gtas/parsers/tamr/TamrAdapterImplTest.java
+++ b/gtas-parent/gtas-parsers/src/test/java/gov/gtas/parsers/tamr/TamrAdapterImplTest.java
@@ -97,19 +97,26 @@ public class TamrAdapterImplTest {
         "{\"id\":null,\"action\":null,\"terms\":[{\"field\":\"firstName\",\"type\":\"string\",\"value\":\"FRIEDA\"},{\"field\":\"lastName\",\"type\":\"string\",\"value\":\"DARRINGTON\"},{\"field\":\"dob\",\"type\":\"date\",\"value\":\"1963-08-13\"}]}",
         "{\"id\":null,\"action\":null,\"terms\":[{\"field\":\"documentType\",\"type\":\"string\",\"value\":\"P\"},{\"field\":\"documentNumber\",\"type\":\"string\",\"value\":\"899294368\"}]}"
 	};
+	public static final String expectedDerogListJson = "{\"passengers\":[" +
+            "{\"gtasId\":\"1\",\"firstName\":\"SHING\",\"middleName\":null,\"lastName\":\"QUAN\",\"gender\":null,\"dob\":\"1998-08-08\",\"documents\":null,\"citizenshipCountry\":null,\"derogId\":\"1\"}," +
+            "{\"gtasId\":\"3\",\"firstName\":\"FRIEDA\",\"middleName\":null,\"lastName\":\"DARRINGTON\",\"gender\":null,\"dob\":\"1963-08-13\",\"documents\":null,\"citizenshipCountry\":null,\"derogId\":\"3\"}" +
+            "]}";
+	
+	public static List<WatchlistItem> getWatchlistItems() {
+        List<WatchlistItem> watchlistItems = new ArrayList<>();
+        for (int i = 0; i < WATCHLIST_ITEMS.length; i++) {
+            WatchlistItem watchlistItem = new WatchlistItem();
+            watchlistItem.setItemData(WATCHLIST_ITEMS[i]);
+            watchlistItem.setId((long) i + 1);
+            watchlistItems.add(watchlistItem);
+        }
+        return watchlistItems;
+	}
 	
 	@Test
 	public void testWatchlistConversion() throws JsonProcessingException {
-	    List<WatchlistItem> watchlistItems = new ArrayList<>();
-	    for (int i = 0; i < WATCHLIST_ITEMS.length; i++) {
-	        WatchlistItem watchlistItem = new WatchlistItem();
-	        watchlistItem.setItemData(WATCHLIST_ITEMS[i]);
-	        watchlistItem.setId((long) i + 1);
-	        watchlistItems.add(watchlistItem);
-	    }
-	    
 	    List<TamrDerogListEntry> derogList = 
-	            tamrAdapter.convertWatchlist(watchlistItems);
+	            tamrAdapter.convertWatchlist(getWatchlistItems());
 	  
 	    // Only 2 entries in the derog list, since document entries should
 	    // be filtered out.

--- a/gtas-parent/gtas-parsers/src/test/java/gov/gtas/parsers/tamr/TamrDerogReplaceSchedulerTest.java
+++ b/gtas-parent/gtas-parsers/src/test/java/gov/gtas/parsers/tamr/TamrDerogReplaceSchedulerTest.java
@@ -1,0 +1,105 @@
+/*
+ * All Application code is Copyright 2016, The Department of Homeland Security (DHS), U.S. Customs and Border Protection (CBP).
+ * 
+ * Please see LICENSE.txt for details.
+ */
+package gov.gtas.parsers.tamr;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import gov.gtas.model.watchlist.Watchlist;
+import gov.gtas.model.watchlist.WatchlistItem;
+import gov.gtas.parsers.tamr.TamrDerogReplaceScheduler;
+import gov.gtas.parsers.tamr.jms.TamrMessageSender;
+import gov.gtas.repository.watchlist.WatchlistItemRepository;
+import gov.gtas.repository.watchlist.WatchlistRepository;
+
+public class TamrDerogReplaceSchedulerTest {
+    private TamrDerogReplaceScheduler scheduler;
+    private TamrMessageSender messageSender;
+    private WatchlistItemRepository watchlistItemRepository;
+    private Watchlist watchlist;
+    private WatchlistRepository watchlistRepository;
+
+    @Before
+    public void setUp() {
+        scheduler = new TamrDerogReplaceScheduler();
+        
+        watchlist = new Watchlist();
+        watchlist.setId(1L);
+        watchlist.setEditTimestamp(new Date());
+        watchlistRepository = mock(WatchlistRepository.class);
+        ReflectionTestUtils.setField(scheduler, "watchlistRepository",
+                watchlistRepository);
+        given(watchlistRepository.findAll())
+                .willReturn(Collections.singletonList(watchlist));
+        
+        List<WatchlistItem> watchlistItems =
+                TamrAdapterImplTest.getWatchlistItems();
+        watchlistItemRepository = mock(WatchlistItemRepository.class);
+        ReflectionTestUtils.setField(scheduler, "watchlistItemRepository",
+                watchlistItemRepository);
+        given(watchlistItemRepository.findAll()).willReturn(watchlistItems);
+   
+        messageSender = mock(TamrMessageSender.class);
+        ReflectionTestUtils.setField(scheduler, "tamrMessageSender",
+                messageSender);
+        doCallRealMethod().when(messageSender).sendMessageToTamr(any(), any());
+    }
+    
+    /**
+     * Make sure watchlist items are sent to Tamr the first time the scheduler
+     * runs.
+     */
+    @Test
+    public void testSendWatchlist() throws InterruptedException {
+        scheduler.jobScheduling();
+
+        ArgumentCaptor<String> messageTypeCaptor =
+                ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> messageTextCaptor =
+                ArgumentCaptor.forClass(String.class);
+        verify(messageSender).sendTextMessageToTamr(
+                messageTypeCaptor.capture(), messageTextCaptor.capture());
+        assertEquals("DC.REPLACE", messageTypeCaptor.getValue());
+        assertEquals(TamrAdapterImplTest.expectedDerogListJson,
+                messageTextCaptor.getValue());
+    }
+    
+    /**
+     * Make sure derog replace isn't sent to Tamr when the watchlists haven't
+     * been edited.
+     * @throws InterruptedException 
+     */
+    @Test
+    public void testNoSendIfNotEdited() throws InterruptedException {
+        scheduler.jobScheduling();
+        scheduler.jobScheduling();
+        scheduler.jobScheduling();
+
+        // Only one message should have been sent.
+        verify(messageSender, times(1)).sendTextMessageToTamr(
+                any(), any());
+        
+        // Now update edited time...
+        watchlist.setEditTimestamp(new Date());
+        // ...and another message should be sent.
+        scheduler.jobScheduling();
+        scheduler.jobScheduling();
+        verify(messageSender, times(2)).sendTextMessageToTamr(
+                any(), any());
+    }
+}


### PR DESCRIPTION
I added a class `TamrDerogReplaceScheduler` which runs a scheduled job every so often. The job checks if any watchlists have been edited since it was last run; if so, it sends the latest derog list to Tamr.

The frequency of the job is specified by the `tamr.derogReplace.initialDelay.in.milliseconds` and `tamr.derogReplace.fixedDelay.in.milliseconds` properties. The initialDelay is how long (in ms) from application startup the job first runs, and fixedDelay is how long (in ms) between job runs. By default, the job runs after 1 second and then every hour, although it only sends the new derog list if there have been updates in GTAS.