### PR TITLE
Feature/quickmatch sparse data

### DIFF
--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/matcher/quickmatch/MatchingContext.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/matcher/quickmatch/MatchingContext.java
@@ -105,6 +105,7 @@ public class MatchingContext {
 
 	// For normal operation: get accuracyMode from config
 	public void initialize(final List<HashMap<String, String>> watchListItems) {
+		this.initializeConfig();
 		this.initialize(watchListItems, this.config.getAccuracyMode());
 	}
 
@@ -117,7 +118,6 @@ public class MatchingContext {
 
 		this.derogList = watchListItems;
 		this.derogList = this.prepareAttributes(this.derogList);
-
 		/**
 		 * Split the list into sets where each matchClause applies; Then, for each
 		 * query, we need only apply a clause to derog records where it is valid.
@@ -402,7 +402,7 @@ public class MatchingContext {
 	/**
 	 * 
 	 * @param travelerDate
-	 * @param deragDate
+	 * @param derogDate
 	 * @return
 	 * @throws ParseException
 	 */
@@ -422,7 +422,7 @@ public class MatchingContext {
 	 * Compares the two Dates for equality
 	 * 
 	 * @param travelerDate
-	 * @param deragDate
+	 * @param derogDate
 	 * @return
 	 */
 	private boolean isSameDOBYearMonthDay(String travelerDate, String derogDate) {
@@ -452,7 +452,6 @@ public class MatchingContext {
 		// one.
 		// but leave the original renames list untouched.
 		HashMap<String, String> batchRenames = new HashMap<>(config.getAttributeRenames());
-
 		// Begin per-record renames and pre-processing
 		// Use iterator so we can remove records with critical errors
 		Iterator<HashMap<String, String>> recordIterator = parsedRecords.iterator();

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/matcher/quickmatch/MatchingContext.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/matcher/quickmatch/MatchingContext.java
@@ -62,6 +62,12 @@ public class MatchingContext {
 	 * queries where Balanced mode may struggle. On other queries, though, it simple
 	 * returns hits that Balanced mode already found.
 	 *
+	 * LowDataOptimized: Higher recall and precision than other modes when both
+	 * (a) the watchlist contains only first name, last name, and DOB, and
+	 * (b) the DOBs contain accurate years but a majority of dummy birtdays, e.g.
+	 * it is known that a traveler or watchlist person was born in 1991, but the
+	 * birthday is arbitrarily chosen to a default value like "January 1."
+	 *
 	 * gtasDefault: The default:
 	 *
 	 */

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/matcher/quickmatch/QuickMatcherConfig.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/matcher/quickmatch/QuickMatcherConfig.java
@@ -9,14 +9,13 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 
-import org.springframework.stereotype.Component;
-
 public class QuickMatcherConfig {
 
 	enum AccuracyMode {
 
 		HIGH_RECALL("highRecall"), BALANCED("balanced"), BALANCED_WITH_TEXT_DISTANCE(
-				"balancedWithTextDistance"), HIGH_PRECISION("highPrecision"), GTAS_DEFAULT("gtasDefault");
+				"balancedWithTextDistance"), HIGH_PRECISION("highPrecision"), GTAS_DEFAULT("gtasDefault"),
+		LOW_DATA_OPTIMIZED("lowDataOptimized");
 
 		private String mode;
 
@@ -71,6 +70,8 @@ public class QuickMatcherConfig {
 	private List<List<String>> balanced;
 	private List<List<String>> highPrecision;
 	private List<List<String>> gtasDefault;
+	private List<List<String>> lowDataOptimized;
+
 
 	public List<List<String>> getGtasDefault() {
 		return gtasDefault;
@@ -107,6 +108,10 @@ public class QuickMatcherConfig {
 		return highPrecision;
 	}
 
+	public List<List<String>> getLowDataOptimized() {
+		return lowDataOptimized;
+	}
+
 	public List<List<String>> getClausesForAccuracyMode(String mode) {
 		HashMap<String, List<List<String>>> modes = new HashMap<>();
 		// We allow the clauses in the modes to be edited,
@@ -116,6 +121,7 @@ public class QuickMatcherConfig {
 		modes.put(AccuracyMode.BALANCED_WITH_TEXT_DISTANCE.toString(), balanced);
 		modes.put(AccuracyMode.HIGH_PRECISION.toString(), highPrecision);
 		modes.put(AccuracyMode.GTAS_DEFAULT.toString(), gtasDefault);
+		modes.put(AccuracyMode.LOW_DATA_OPTIMIZED.toString(), lowDataOptimized);
 		return modes.get(mode);
 	}
 

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/matcher/quickmatch/QuickMatcherConfig.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/matcher/quickmatch/QuickMatcherConfig.java
@@ -52,6 +52,12 @@ public class QuickMatcherConfig {
 	 * extra algorithm finds more true hits than Balanced mode alone, for some
 	 * queries where Balanced mode may struggle. On other queries, though, it simple
 	 * returns hits that Balanced mode already found.
+     *
+     * LowDataOptimized: Higher recall and precision than other modes when both
+     * (a) the watchlist contains only first name, last name, and DOB, and
+     * (b) the DOBs contain accurate years but a majority of dummy birtdays, e.g.
+     * it is known that a traveler or watchlist person was born in 1991, but the
+     * birthday is arbitrarily chosen to a default value like "January 1."
 	 * 
 	 * gtasDefault: The default:
 	 * 

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/matcher/quickmatch/QuickMatcherImpl.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/matcher/quickmatch/QuickMatcherImpl.java
@@ -5,18 +5,13 @@
  */
 package gov.gtas.services.matcher.quickmatch;
 
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
+import gov.gtas.model.Passenger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import gov.gtas.model.Passenger;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class QuickMatcherImpl implements QuickMatcher {
 
@@ -28,6 +23,7 @@ public class QuickMatcherImpl implements QuickMatcher {
 	private final MatchingContext cxt;
 	private static final Set<Long> EMPTY_DEROGLIST = new HashSet<>();
 
+	// For normal operations, the MatchingContext gets accuracyMode from config files
 	public QuickMatcherImpl(final List<HashMap<String, String>> watchListItems) {
 		this.cxt = new MatchingContext();
 
@@ -36,6 +32,17 @@ public class QuickMatcherImpl implements QuickMatcher {
 			this.cxt.initialize(new ArrayList<>());
 		else
 			this.cxt.initialize(watchListItems);
+	}
+
+	// For testing, to force and accuracyMode
+	public QuickMatcherImpl(final List<HashMap<String, String>> watchListItems, final String accuracyMode) {
+		this.cxt = new MatchingContext();
+
+		// sanity check
+		if (watchListItems == null)
+			this.cxt.initialize(new ArrayList<>(), accuracyMode);
+		else
+			this.cxt.initialize(watchListItems, accuracyMode);
 	}
 
 	public MatchingContext getCxt() {

--- a/gtas-parent/gtas-commons/src/main/resources/QMConfig.yaml
+++ b/gtas-parent/gtas-commons/src/main/resources/QMConfig.yaml
@@ -3,6 +3,7 @@
 # Balanced
 # HighRecall
 # HighPrecision
+# LowDataOptimized
 accuracyMode: gtasDefault
 
 derogFilterOutRegex: "^(UNKNOWN|other|NA|\\?|_)$"

--- a/gtas-parent/gtas-commons/src/main/resources/QMConfig.yaml
+++ b/gtas-parent/gtas-commons/src/main/resources/QMConfig.yaml
@@ -99,4 +99,14 @@ gtasDefault:
         - first_name
         - DOB_Date
         - metaphones
-        
+
+lowDataOptimized:
+    -
+        - full_name
+        - dob_year
+    -
+        - metaphones
+        - dob_year
+    -
+        - nysiis
+        - dob_year

--- a/gtas-parent/gtas-commons/src/test/java/gov/gtas/services/QuickMatcherTest.java
+++ b/gtas-parent/gtas-commons/src/test/java/gov/gtas/services/QuickMatcherTest.java
@@ -8,8 +8,15 @@
 
 package gov.gtas.services;
 
-import static gov.gtas.services.matcher.quickmatch.MatchingContext.DOB_YEAR_OFFSET;
-import static org.junit.Assert.assertEquals;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.gtas.model.Passenger;
+import gov.gtas.model.PassengerDetails;
+import gov.gtas.model.watchlist.json.WatchlistItemSpec;
+import gov.gtas.services.matcher.quickmatch.DerogHit;
+import gov.gtas.services.matcher.quickmatch.MatchingResult;
+import gov.gtas.services.matcher.quickmatch.QuickMatcher;
+import gov.gtas.services.matcher.quickmatch.QuickMatcherImpl;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.text.ParseException;
@@ -18,17 +25,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import gov.gtas.services.matcher.quickmatch.QuickMatcherImpl;
-import org.junit.Test;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import gov.gtas.model.Passenger;
-import gov.gtas.model.PassengerDetails;
-import gov.gtas.model.watchlist.json.WatchlistItemSpec;
-import gov.gtas.services.matcher.quickmatch.DerogHit;
-import gov.gtas.services.matcher.quickmatch.MatchingResult;
-import gov.gtas.services.matcher.quickmatch.QuickMatcher;
+import static gov.gtas.services.matcher.quickmatch.MatchingContext.DOB_YEAR_OFFSET;
+import static org.junit.Assert.assertEquals;
 
 public class QuickMatcherTest {
 
@@ -70,6 +68,36 @@ public class QuickMatcherTest {
 
 		QuickMatcher qm = new QuickMatcherImpl(derogList);
 		MatchingResult result = qm.match(p, .80F, DOB_YEAR_OFFSET);
+		result.getResponses();
+
+		assertEquals(1, result.getTotalHits());
+
+	}
+
+	@Test
+	public void testLowDataOptimizedDobYear() throws IOException {
+
+		Passenger p = getTestPassenger(1, "John", "Doe", null, "1988-01-01");
+
+		List<HashMap<String, String>> derogList = getTestWL(11, "John", "Doe", "1988-03-15");
+
+		QuickMatcher qm = new QuickMatcherImpl(derogList, "lowDataOptimized");
+		MatchingResult result = qm.match(p);
+		result.getResponses();
+
+		assertEquals(1, result.getTotalHits());
+
+	}
+
+	@Test
+	public void testLowDataOptimizedNYSIIS() throws IOException {
+
+		Passenger p = getTestPassenger(1, "Josh", "MCKENZIE", null, "1988-01-01");
+
+		List<HashMap<String, String>> derogList = getTestWL(11, "Joshua", "MACKENZIE", "1988-03-15");
+
+		QuickMatcher qm = new QuickMatcherImpl(derogList, "lowDataOptimized");
+		MatchingResult result = qm.match(p);
 		result.getResponses();
 
 		assertEquals(1, result.getTotalHits());


### PR DESCRIPTION
Added new accuracy mode, which requires computing dob_year and NYSIIS phonetic tokens for derog and traveler records.